### PR TITLE
feat(search): collapsible filter sections + mobile sidebar toggle

### DIFF
--- a/src/components/search/FilterSidebar.tsx
+++ b/src/components/search/FilterSidebar.tsx
@@ -43,19 +43,97 @@ const LANGUAGE_OPTIONS = [
   { value: 'ru', label: 'רוסית' },
 ];
 
+// Inline chevron — rotates 180° when section is expanded
+function ChevronIcon({ open }: { open: boolean }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={cn(
+        'flex-shrink-0 text-text-secondary transition-transform duration-200',
+        open ? 'rotate-180' : 'rotate-0'
+      )}
+      aria-hidden="true"
+    >
+      <polyline points="6 9 12 15 18 9" />
+    </svg>
+  );
+}
+
+// Funnel icon for the mobile "Show filters" button
+function FunnelIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="15"
+      height="15"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+    </svg>
+  );
+}
+
+/**
+ * Collapsible filter section.
+ *
+ * Uses the CSS grid trick (`grid-rows-[0fr]` ↔ `grid-rows-[1fr]`) for a
+ * smooth height transition without needing to know the content height.
+ * The inner wrapper must have `overflow-hidden` to clip the content
+ * when the row is animating to zero height.
+ */
 function FilterSection({
   title,
   children,
+  defaultOpen = true,
 }: {
   title: string;
   children: React.ReactNode;
+  defaultOpen?: boolean;
 }) {
+  const [open, setOpen] = useState(defaultOpen);
+  const panelId = `filter-${title.toLowerCase().replace(/\s+/g, '-')}`;
+
   return (
-    <div className="flex flex-col gap-2.5">
-      <h3 className="text-[11px] font-semibold uppercase tracking-wider text-text-secondary">
-        {title}
-      </h3>
-      <div className="flex flex-col gap-2">{children}</div>
+    <div className="flex flex-col">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+        aria-controls={panelId}
+        className="flex w-full items-center justify-between py-0.5 text-start"
+      >
+        <h3 className="text-[11px] font-semibold uppercase tracking-wider text-text-secondary">
+          {title}
+        </h3>
+        <ChevronIcon open={open} />
+      </button>
+
+      {/* Grid trick: animates between grid-rows-[0fr] and grid-rows-[1fr] */}
+      <div
+        id={panelId}
+        className={cn(
+          'grid transition-[grid-template-rows] duration-200',
+          open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
+        )}
+      >
+        <div className="overflow-hidden">
+          <div className="flex flex-col gap-2 pb-0.5 pt-2.5">{children}</div>
+        </div>
+      </div>
     </div>
   );
 }
@@ -89,6 +167,9 @@ function CheckboxItem({
 export default function FilterSidebar() {
   const tSearch = useTranslations('search');
 
+  // Mobile: controls whether the entire panel is visible
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   const [selectedSpecialties, setSelectedSpecialties] = useState<string[]>([]);
   const [selectedInsurance, setSelectedInsurance] = useState<string[]>([]);
   const [selectedSessionTypes, setSelectedSessionTypes] = useState<string[]>([]);
@@ -115,124 +196,160 @@ export default function FilterSidebar() {
     setAcceptingOnly(false);
   }
 
-  const hasFilters =
-    selectedSpecialties.length > 0 ||
-    selectedInsurance.length > 0 ||
-    selectedSessionTypes.length > 0 ||
-    selectedLanguages.length > 0 ||
-    acceptingOnly;
+  const activeFilterCount =
+    selectedSpecialties.length +
+    selectedInsurance.length +
+    selectedSessionTypes.length +
+    selectedLanguages.length +
+    (acceptingOnly ? 1 : 0);
+
+  const hasFilters = activeFilterCount > 0;
 
   return (
-    <aside className="md:sticky md:top-20 flex flex-col gap-5 rounded-lg border border-border bg-surface p-5 shadow-card md:w-72 md:flex-shrink-0">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold text-text-primary">
-          {tSearch('sortBy')}
-        </h2>
-        {hasFilters && (
+    <div className="md:w-72 md:flex-shrink-0">
+      {/* Mobile toggle button — only visible below md breakpoint */}
+      <button
+        type="button"
+        onClick={() => setSidebarOpen((prev) => !prev)}
+        aria-expanded={sidebarOpen}
+        aria-controls="filter-sidebar-panel"
+        className={cn(
+          'md:hidden mb-3 flex w-full items-center gap-2 rounded-lg border border-border bg-surface px-4 py-2.5 text-sm font-medium text-text-primary shadow-sm transition-colors hover:bg-bg',
+          sidebarOpen && 'bg-bg border-primary/30'
+        )}
+      >
+        <FunnelIcon />
+        <span className="flex-1 text-start">
+          {sidebarOpen ? tSearch('hideFilters') : tSearch('showFilters')}
+        </span>
+        {activeFilterCount > 0 && (
+          <span className="rounded-full bg-primary px-2 py-0.5 text-xs font-semibold leading-none text-white">
+            {activeFilterCount}
+          </span>
+        )}
+      </button>
+
+      {/* Filter panel — hidden on mobile until toggled, always visible on md+ */}
+      <aside
+        id="filter-sidebar-panel"
+        className={cn(
+          'flex flex-col gap-4 rounded-lg border border-border bg-surface p-5 shadow-card',
+          // Desktop: always shown as sticky sidebar
+          'md:flex md:sticky md:top-20',
+          // Mobile: toggled
+          sidebarOpen ? 'flex' : 'hidden'
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold text-text-primary">
+            {tSearch('sortBy')}
+          </h2>
+          {hasFilters && (
+            <button
+              type="button"
+              onClick={clearAll}
+              className="text-xs font-medium text-primary hover:underline"
+            >
+              נקה הכל
+            </button>
+          )}
+        </div>
+
+        <div className="h-px bg-border" />
+
+        {/* Specialisation */}
+        <FilterSection title={tSearch('filters.specialisation')}>
+          {SPECIALTIES.map((s) => (
+            <CheckboxItem
+              key={s.value}
+              label={SPECIALTY_LABELS[s.value]}
+              checked={selectedSpecialties.includes(s.value)}
+              onChange={() =>
+                toggleItem(s.value, selectedSpecialties, setSelectedSpecialties)
+              }
+            />
+          ))}
+        </FilterSection>
+
+        <div className="h-px bg-border" />
+
+        {/* Insurance */}
+        <FilterSection title={tSearch('filters.insurance')}>
+          {INSURANCE_OPTIONS.map((opt) => (
+            <CheckboxItem
+              key={opt.value}
+              label={opt.label}
+              checked={selectedInsurance.includes(opt.value)}
+              onChange={() =>
+                toggleItem(opt.value, selectedInsurance, setSelectedInsurance)
+              }
+            />
+          ))}
+        </FilterSection>
+
+        <div className="h-px bg-border" />
+
+        {/* Session type */}
+        <FilterSection title={tSearch('filters.sessionType')}>
+          {SESSION_TYPE_OPTIONS.map((opt) => (
+            <CheckboxItem
+              key={opt.value}
+              label={opt.label}
+              checked={selectedSessionTypes.includes(opt.value)}
+              onChange={() =>
+                toggleItem(
+                  opt.value,
+                  selectedSessionTypes,
+                  setSelectedSessionTypes
+                )
+              }
+            />
+          ))}
+        </FilterSection>
+
+        <div className="h-px bg-border" />
+
+        {/* Language */}
+        <FilterSection title={tSearch('filters.language')}>
+          {LANGUAGE_OPTIONS.map((opt) => (
+            <CheckboxItem
+              key={opt.value}
+              label={opt.label}
+              checked={selectedLanguages.includes(opt.value)}
+              onChange={() =>
+                toggleItem(opt.value, selectedLanguages, setSelectedLanguages)
+              }
+            />
+          ))}
+        </FilterSection>
+
+        <div className="h-px bg-border" />
+
+        {/* Accepting patients toggle */}
+        <label className="flex cursor-pointer items-center justify-between gap-3">
+          <span className="text-sm font-medium text-text-primary">
+            מקבל/ת מטופלים חדשים
+          </span>
           <button
             type="button"
-            onClick={clearAll}
-            className="text-xs font-medium text-primary hover:underline"
-          >
-            נקה הכל
-          </button>
-        )}
-      </div>
-
-      <div className="h-px bg-border" />
-
-      {/* Specialisation */}
-      <FilterSection title={tSearch('filters.specialisation')}>
-        {SPECIALTIES.map((s) => (
-          <CheckboxItem
-            key={s.value}
-            label={SPECIALTY_LABELS[s.value]}
-            checked={selectedSpecialties.includes(s.value)}
-            onChange={() =>
-              toggleItem(s.value, selectedSpecialties, setSelectedSpecialties)
-            }
-          />
-        ))}
-      </FilterSection>
-
-      <div className="h-px bg-border" />
-
-      {/* Insurance */}
-      <FilterSection title={tSearch('filters.insurance')}>
-        {INSURANCE_OPTIONS.map((opt) => (
-          <CheckboxItem
-            key={opt.value}
-            label={opt.label}
-            checked={selectedInsurance.includes(opt.value)}
-            onChange={() =>
-              toggleItem(opt.value, selectedInsurance, setSelectedInsurance)
-            }
-          />
-        ))}
-      </FilterSection>
-
-      <div className="h-px bg-border" />
-
-      {/* Session type */}
-      <FilterSection title={tSearch('filters.sessionType')}>
-        {SESSION_TYPE_OPTIONS.map((opt) => (
-          <CheckboxItem
-            key={opt.value}
-            label={opt.label}
-            checked={selectedSessionTypes.includes(opt.value)}
-            onChange={() =>
-              toggleItem(
-                opt.value,
-                selectedSessionTypes,
-                setSelectedSessionTypes
-              )
-            }
-          />
-        ))}
-      </FilterSection>
-
-      <div className="h-px bg-border" />
-
-      {/* Language */}
-      <FilterSection title={tSearch('filters.language')}>
-        {LANGUAGE_OPTIONS.map((opt) => (
-          <CheckboxItem
-            key={opt.value}
-            label={opt.label}
-            checked={selectedLanguages.includes(opt.value)}
-            onChange={() =>
-              toggleItem(opt.value, selectedLanguages, setSelectedLanguages)
-            }
-          />
-        ))}
-      </FilterSection>
-
-      <div className="h-px bg-border" />
-
-      {/* Accepting patients toggle */}
-      <label className="flex cursor-pointer items-center justify-between gap-3">
-        <span className="text-sm font-medium text-text-primary">
-          מקבל/ת מטופלים חדשים
-        </span>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={acceptingOnly}
-          onClick={() => setAcceptingOnly((prev) => !prev)}
-          className={cn(
-            'relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200',
-            acceptingOnly ? 'bg-primary' : 'bg-border'
-          )}
-        >
-          <span
+            role="switch"
+            aria-checked={acceptingOnly}
+            onClick={() => setAcceptingOnly((prev) => !prev)}
             className={cn(
-              'pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow transition duration-200',
-              acceptingOnly ? 'translate-x-4' : 'translate-x-0'
+              'relative inline-flex h-5 w-9 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200',
+              acceptingOnly ? 'bg-primary' : 'bg-border'
             )}
-          />
-        </button>
-      </label>
-    </aside>
+          >
+            <span
+              className={cn(
+                'pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow transition duration-200',
+                acceptingOnly ? 'translate-x-4' : 'translate-x-0'
+              )}
+            />
+          </button>
+        </label>
+      </aside>
+    </div>
   );
 }

--- a/src/messages/ar.json
+++ b/src/messages/ar.json
@@ -35,6 +35,9 @@
     "title": "البحث عن المعالجين الوظيفيين",
     "results": "تم العثور على {count} معالج",
     "noResults": "لم يتم العثور على معالجين يطابقون بحثك",
+    "showFilters": "عرض الفلاتر",
+    "hideFilters": "إخفاء الفلاتر",
+    "activeFilters": "{count} فلاتر نشطة",
     "sortBy": "ترتيب حسب",
     "sortOptions": {
       "relevance": "الصلة",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -35,6 +35,9 @@
     "title": "Find Occupational Therapists",
     "results": "{count} therapists found",
     "noResults": "No therapists found matching your search",
+    "showFilters": "Show filters",
+    "hideFilters": "Hide filters",
+    "activeFilters": "{count} active filters",
     "sortBy": "Sort by",
     "sortOptions": {
       "relevance": "Relevance",

--- a/src/messages/he.json
+++ b/src/messages/he.json
@@ -35,6 +35,9 @@
     "title": "חיפוש מרפאים בעיסוק",
     "results": "{count} מרפאים נמצאו",
     "noResults": "לא נמצאו מרפאים התואמים לחיפוש שלך",
+    "showFilters": "הצג מסננים",
+    "hideFilters": "הסתר מסננים",
+    "activeFilters": "{count} מסננים פעילים",
     "sortBy": "מיין לפי",
     "sortOptions": {
       "relevance": "רלוונטיות",


### PR DESCRIPTION
## Summary

- **Per-section collapse** — each filter group (Specialisation, Insurance, Session type, Language) now has a chevron toggle that collapses its content independently. Uses the CSS grid trick (`grid-rows-[0fr]` ↔ `grid-rows-[1fr]`) for smooth height animation with no new dependencies.
- **Mobile sidebar toggle** — a "Show filters" / "Hide filters" button appears below the `md` breakpoint, replacing the always-visible sidebar with an on-demand panel. Includes an active-filter count badge so users know when filters are applied even while the panel is hidden.
- **Accessibility** — `aria-expanded` and `aria-controls` on all toggle buttons; chevron rotation is purely decorative (`aria-hidden`).
- **i18n** — `showFilters`, `hideFilters`, `activeFilters` keys added to `he.json`, `en.json`, `ar.json`.

## Test plan

- [ ] Desktop: sidebar always visible, each section header click collapses/expands with smooth animation, chevron rotates
- [ ] Desktop: collapsing one section does not affect others
- [ ] Mobile (< md): "הצג מסננים" button visible above results, no sidebar
- [ ] Mobile: tap button → sidebar expands; tap again → collapses
- [ ] Mobile: select 2 filters, collapse sidebar → badge shows `2` on the button
- [ ] `/en/search` mobile: button shows "Show filters" / "Hide filters"
- [ ] `/ar/search`: RTL layout intact, chevrons and button render correctly
- [ ] `npm run lint && npm run typecheck && npm run test && npm run build` all pass