### PR TITLE
fix: handle DB errors in search & profile pages to prevent 500 on Vercel

### DIFF
--- a/src/app/[locale]/(public)/ot/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/ot/[slug]/page.tsx
@@ -44,7 +44,11 @@ interface OTProfilePageProps {
 export default async function OTProfilePage({ params }: OTProfilePageProps) {
   const { slug } = await params;
   const locale = await getLocale();
-  const ot = await getOTBySlug(slug);
+
+  const ot = await getOTBySlug(slug).catch((err: unknown) => {
+    console.error('[OTProfilePage] getOTBySlug failed:', err);
+    return null;
+  });
 
   if (!ot) notFound();
 

--- a/src/app/[locale]/(public)/search/page.tsx
+++ b/src/app/[locale]/(public)/search/page.tsx
@@ -3,6 +3,7 @@ import { getLocale } from 'next-intl/server';
 import { searchOTs } from '@/lib/db/ots';
 import OTCard from '@/components/search/OTCard';
 import FilterSidebar from '@/components/search/FilterSidebar';
+import type { OTProfilePublic } from '@/types';
 
 interface SearchPageProps {
   searchParams: Promise<{
@@ -22,17 +23,26 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
   const t = await getTranslations('search');
   const locale = await getLocale();
 
-  const { profiles, total } = await searchOTs({
-    q: sp.q,
-    specialisation: sp.specialisation,
-    insurance: sp.insurance,
-    sessionType: sp.sessionType,
-    language: sp.language,
-    city: sp.city,
-    acceptingOnly: sp.acceptingOnly === 'true',
-    page: sp.page ? parseInt(sp.page, 10) : 1,
-    limit: 20,
-  });
+  let profiles: OTProfilePublic[] = [];
+  let total = 0;
+  let dbError = false;
+
+  try {
+    ({ profiles, total } = await searchOTs({
+      q: sp.q,
+      specialisation: sp.specialisation,
+      insurance: sp.insurance,
+      sessionType: sp.sessionType,
+      language: sp.language,
+      city: sp.city,
+      acceptingOnly: sp.acceptingOnly === 'true',
+      page: sp.page ? parseInt(sp.page, 10) : 1,
+      limit: 20,
+    }));
+  } catch (err) {
+    console.error('[SearchPage] searchOTs failed:', err);
+    dbError = true;
+  }
 
   return (
     <div className="min-h-screen bg-bg">
@@ -40,42 +50,78 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
       <div className="border-b border-border bg-surface">
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
           <h1 className="text-2xl font-bold text-text-primary">{t('title')}</h1>
-          <p className="mt-1 text-sm text-text-secondary">
-            {t('results', { count: total })}
-            {sp.q && (
-              <span className="ms-1 font-medium text-primary">&ldquo;{sp.q}&rdquo;</span>
-            )}
-          </p>
+          {!dbError && (
+            <p className="mt-1 text-sm text-text-secondary">
+              {t('results', { count: total })}
+              {sp.q && (
+                <span className="ms-1 font-medium text-primary">&ldquo;{sp.q}&rdquo;</span>
+              )}
+            </p>
+          )}
         </div>
       </div>
 
       {/* Content */}
       <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
-        <div className="flex flex-col gap-6 md:flex-row md:items-start">
-          {/* Sidebar */}
-          <FilterSidebar />
+        {dbError ? (
+          <ServiceUnavailableBanner />
+        ) : (
+          <div className="flex flex-col gap-6 md:flex-row md:items-start">
+            {/* Sidebar */}
+            <FilterSidebar />
 
-          {/* Results */}
-          <div className="flex-1 min-w-0">
-            {profiles.length === 0 ? (
-              <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-surface py-16 text-center">
-                <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="mb-3 text-text-muted" aria-hidden="true">
-                  <circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" />
-                </svg>
-                <p className="text-base font-medium text-text-secondary">
-                  {t('noResults')}
-                </p>
-              </div>
-            ) : (
-              <div className="flex flex-col gap-4">
-                {profiles.map((ot) => (
-                  <OTCard key={ot.id} ot={ot} locale={locale} />
-                ))}
-              </div>
-            )}
+            {/* Results */}
+            <div className="flex-1 min-w-0">
+              {profiles.length === 0 ? (
+                <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-surface py-16 text-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="mb-3 text-text-muted" aria-hidden="true">
+                    <circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" />
+                  </svg>
+                  <p className="text-base font-medium text-text-secondary">
+                    {t('noResults')}
+                  </p>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-4">
+                  {profiles.map((ot) => (
+                    <OTCard key={ot.id} ot={ot} locale={locale} />
+                  ))}
+                </div>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
+    </div>
+  );
+}
+
+function ServiceUnavailableBanner() {
+  return (
+    <div className="flex flex-col items-center justify-center rounded-lg border border-amber-200 bg-amber-50 py-16 text-center">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="40"
+        height="40"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="mb-3 text-amber-500"
+        aria-hidden="true"
+      >
+        <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+        <line x1="12" y1="9" x2="12" y2="13" />
+        <line x1="12" y1="17" x2="12.01" y2="17" />
+      </svg>
+      <p className="text-base font-semibold text-amber-800">
+        Search is temporarily unavailable
+      </p>
+      <p className="mt-1 text-sm text-amber-700">
+        We&apos;re having trouble connecting to our database. Please try again shortly.
+      </p>
     </div>
   );
 }

--- a/src/app/[locale]/error.tsx
+++ b/src/app/[locale]/error.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTranslations } from 'next-intl';
+
+interface ErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function Error({ error, reset }: ErrorProps) {
+  const t = useTranslations('common');
+
+  useEffect(() => {
+    console.error('[locale/error]', error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[calc(100vh-4rem)] flex-col items-center justify-center px-4 py-16 text-center">
+      <div className="mb-6">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="48"
+          height="48"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="mx-auto text-red-400"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <line x1="12" y1="8" x2="12" y2="12" />
+          <line x1="12" y1="16" x2="12.01" y2="16" />
+        </svg>
+      </div>
+      <h1 className="mb-2 text-xl font-bold text-text-primary">{t('error')}</h1>
+      <p className="mb-6 max-w-sm text-sm text-text-secondary">
+        {error.message || 'An unexpected error occurred. Please try again.'}
+      </p>
+      <button
+        onClick={reset}
+        className="rounded-lg bg-primary px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-primary/90"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #138

- **search/page.tsx**: wrap  in try/catch; render a friendly "temporarily unavailable" banner instead of crashing the page
- **ot/[slug]/page.tsx**: catch  errors and fall through to  (404) rather than an unhandled 500
- **[locale]/error.tsx**: add a locale-level React error boundary as a safety net for any future unhandled exceptions in locale routes

## Root cause

 calls  which throws  if the env var is absent (or any other DB error). Neither page had try/catch, so the error surfaced as a Next.js 500 crash.

## Test plan
- [ ] With  missing: visiting  shows the amber warning banner (not 500)
- [ ] With  missing: visiting  shows 404 (not 500)
- [ ] With a valid DB connection: search and profile pages work as before
- [ ] CI: lint + typecheck + test + build all green

https://claude.ai/code/session_01NNxSVjbtxtsbrL1ZhmEZfx