### PR TITLE
feat: home page becomes search directory; role-aware navbar

### DIFF
--- a/src/app/[locale]/(public)/page.tsx
+++ b/src/app/[locale]/(public)/page.tsx
@@ -1,18 +1,109 @@
-import { getTranslations } from 'next-intl/server';
+import { getTranslations, getLocale } from 'next-intl/server';
+import { searchOTs } from '@/lib/db/ots';
+import { searchMockOTs } from '@/lib/mock-search';
 import SearchBar from '@/components/home/SearchBar';
+import FilterSidebar from '@/components/search/FilterSidebar';
+import OTCard from '@/components/search/OTCard';
+import type { OTProfilePublic, SearchParams } from '@/types';
 
-export default async function HomePage() {
-  const t = await getTranslations('home');
+interface HomePageProps {
+  searchParams: Promise<{
+    q?: string;
+    specialisation?: string | string[];
+    insurance?: string | string[];
+    sessionType?: string | string[];
+    language?: string | string[];
+    city?: string;
+    acceptingOnly?: string;
+    page?: string;
+  }>;
+}
+
+export default async function HomePage({ searchParams }: HomePageProps) {
+  const sp = await searchParams;
+  const tHome = await getTranslations('home');
+  const tSearch = await getTranslations('search');
+  const locale = await getLocale();
+
+  const query: SearchParams = {
+    q: sp.q,
+    specialisation: sp.specialisation as SearchParams['specialisation'],
+    insurance: sp.insurance as SearchParams['insurance'],
+    sessionType: sp.sessionType as SearchParams['sessionType'],
+    language: sp.language,
+    city: sp.city,
+    acceptingOnly: sp.acceptingOnly === 'true',
+    page: sp.page ? parseInt(sp.page, 10) : 1,
+    limit: 20,
+  };
+
+  let profiles: OTProfilePublic[] = [];
+  let total = 0;
+  let usingMockData = false;
+
+  try {
+    ({ profiles, total } = await searchOTs(query));
+  } catch (err) {
+    console.warn('[HomePage] DB unavailable, falling back to mock data:', (err as Error).message);
+    ({ profiles, total } = searchMockOTs(query));
+    usingMockData = true;
+  }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-bg px-4">
-      <div className="w-full max-w-3xl text-center">
-        <h1 className="mb-4 text-4xl font-extrabold tracking-tight text-text-primary lg:text-5xl">
-          {t('heroTitle')}
-        </h1>
-        <p className="mb-8 text-lg text-text-secondary">{t('heroSubtitle')}</p>
-        <SearchBar />
+    <div className="min-h-screen bg-bg">
+      {/* Compact hero */}
+      <div className="border-b border-border bg-surface">
+        <div className="mx-auto max-w-3xl px-4 py-10 text-center sm:px-6 lg:px-8">
+          <h1 className="mb-3 text-3xl font-extrabold tracking-tight text-text-primary sm:text-4xl">
+            {tHome('heroTitle')}
+          </h1>
+          <p className="mb-6 text-base text-text-secondary">{tHome('heroSubtitle')}</p>
+          <SearchBar />
+        </div>
       </div>
-    </main>
+
+      {/* Results count bar */}
+      <div className="border-b border-border bg-bg">
+        <div className="mx-auto max-w-7xl px-4 py-3 sm:px-6 lg:px-8">
+          <p className="text-sm text-text-secondary">
+            {tSearch('results', { count: total })}
+            {sp.q && (
+              <span className="ms-1 font-medium text-primary">&ldquo;{sp.q}&rdquo;</span>
+            )}
+            {usingMockData && (
+              <span className="ms-2 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+                demo data
+              </span>
+            )}
+          </p>
+        </div>
+      </div>
+
+      {/* Filters + results */}
+      <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div className="flex flex-col gap-6 md:flex-row md:items-start">
+          <FilterSidebar />
+
+          <div className="flex-1 min-w-0">
+            {profiles.length === 0 ? (
+              <div className="flex flex-col items-center justify-center rounded-lg border border-dashed border-border bg-surface py-16 text-center">
+                <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="mb-3 text-text-muted" aria-hidden="true">
+                  <circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" />
+                </svg>
+                <p className="text-base font-medium text-text-secondary">
+                  {tSearch('noResults')}
+                </p>
+              </div>
+            ) : (
+              <div className="flex flex-col gap-4">
+                {profiles.map((ot) => (
+                  <OTCard key={ot.id} ot={ot} locale={locale} t={tSearch} />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/components/home/SearchBar.tsx
+++ b/src/components/home/SearchBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter } from '@/i18n/navigation';
 import { useTranslations } from 'next-intl';
 
 export default function SearchBar() {
@@ -12,7 +12,7 @@ export default function SearchBar() {
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     const params = query.trim() ? `?q=${encodeURIComponent(query.trim())}` : '';
-    router.push(`/search${params}`);
+    router.push(`/${params}`);
   }
 
   return (

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,19 +3,15 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useSession, signOut } from 'next-auth/react';
-import { Link, usePathname } from '@/i18n/navigation';
-import { cn } from '@/lib/utils';
+import { Link } from '@/i18n/navigation';
 
 export default function Navbar() {
   const t = useTranslations('nav');
-  const pathname = usePathname();
   const [mobileOpen, setMobileOpen] = useState(false);
   const { data: session } = useSession();
   const isLoggedIn = !!session?.user;
-
-  const navLinks = [
-    { href: '/search', label: t('search') },
-  ];
+  const role = (session?.user as { role?: string } | undefined)?.role;
+  const isOT = role === 'ot';
 
   const close = () => setMobileOpen(false);
 
@@ -27,26 +23,18 @@ export default function Navbar() {
           <span className="text-xl font-bold text-primary tracking-tight">Therapio</span>
         </Link>
 
-        {/* Desktop nav links */}
-        <nav className="hidden md:flex items-center gap-6">
-          {navLinks.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className={cn(
-                'text-sm font-medium transition-colors hover:text-primary',
-                pathname === link.href ? 'text-primary' : 'text-text-secondary'
-              )}
-            >
-              {link.label}
-            </Link>
-          ))}
-        </nav>
-
         {/* Desktop auth */}
         <div className="hidden md:flex items-center gap-3">
           {isLoggedIn ? (
             <>
+              {isOT && (
+                <Link
+                  href="/dashboard/edit"
+                  className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:border-primary hover:text-primary"
+                >
+                  {t('editProfile')}
+                </Link>
+              )}
               <Link
                 href="/dashboard"
                 className="rounded-lg border border-border px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:border-primary hover:text-primary"
@@ -102,25 +90,23 @@ export default function Navbar() {
       {/* Mobile menu */}
       {mobileOpen && (
         <div className="border-t border-border bg-surface px-4 pb-4 md:hidden">
-          <nav className="flex flex-col gap-1 pt-3">
-            {navLinks.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                onClick={close}
-                className={cn(
-                  'rounded-lg px-3 py-2 text-sm font-medium transition-colors hover:bg-bg-alt hover:text-primary',
-                  pathname === link.href ? 'bg-primary-light text-primary' : 'text-text-secondary'
-                )}
-              >
-                {link.label}
-              </Link>
-            ))}
-          </nav>
           <div className="mt-3 flex flex-col gap-2">
             {isLoggedIn ? (
               <>
-                <Link href="/dashboard" onClick={close} className="rounded-lg border border-border px-4 py-2 text-center text-sm font-medium text-text-primary transition-colors hover:border-primary hover:text-primary">
+                {isOT && (
+                  <Link
+                    href="/dashboard/edit"
+                    onClick={close}
+                    className="rounded-lg border border-border px-4 py-2 text-center text-sm font-medium text-text-primary transition-colors hover:border-primary hover:text-primary"
+                  >
+                    {t('editProfile')}
+                  </Link>
+                )}
+                <Link
+                  href="/dashboard"
+                  onClick={close}
+                  className="rounded-lg border border-border px-4 py-2 text-center text-sm font-medium text-text-primary transition-colors hover:border-primary hover:text-primary"
+                >
                   {t('dashboard')}
                 </Link>
                 <button

--- a/src/messages/ar.json
+++ b/src/messages/ar.json
@@ -18,6 +18,7 @@
     "register": "التسجيل",
     "dashboard": "لوحة التحكم",
     "profile": "الملف الشخصي",
+    "editProfile": "تعديل الملف",
     "logout": "تسجيل الخروج"
   },
   "home": {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -18,6 +18,7 @@
     "register": "Register",
     "dashboard": "Dashboard",
     "profile": "Profile",
+    "editProfile": "Edit profile",
     "logout": "Log out"
   },
   "home": {

--- a/src/messages/he.json
+++ b/src/messages/he.json
@@ -18,6 +18,7 @@
     "register": "הרשמה",
     "dashboard": "לוח בקרה",
     "profile": "פרופיל",
+    "editProfile": "ערוך פרופיל",
     "logout": "יציאה"
   },
   "home": {


### PR DESCRIPTION
- Remove 'Find Therapists' nav link; home page IS the search experience
- Home page renders compact hero + FilterSidebar + OTCard results, mirroring SearchPage with a hero section on top; supports all searchParams
- SearchBar now pushes to / (not /search) with locale-aware router
- Navbar is role-aware: OT users see Edit Profile + Dashboard + Logout, patient users see Dashboard + Logout, guests see Login + Register
- Add nav.editProfile i18n key to he/ar/en locale files
- Remove unused cn import from Navbar

https://claude.ai/code/session_01M57yXwq6sNePvqMg4twCV7

## What does this PR do?

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Infra / config

## Related issue
Closes #

## Checklist
- [ ] All CI checks pass locally (`npm run lint && npm run typecheck && npm run test && npm run build`)
- [ ] Tests written for new logic
- [ ] Tested in Hebrew RTL layout
- [ ] No hardcoded strings — all text via i18n
- [ ] No TypeScript `any` types
- [ ] New env variables documented in `.env.example`
- [ ] No secrets committed
