### PR TITLE
feat(epic-6): rename OT→Therapist + gender field + i18n cleanup

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -35,6 +35,7 @@ const profiles = [
     subscriptionTier: 'premium' as const,
     isFeatured: true,
     isAcceptingPatients: true,
+    gender: 'female' as const,
   },
   {
     slug: 'yosef-levi',
@@ -57,6 +58,7 @@ const profiles = [
     subscriptionTier: 'premium' as const,
     isFeatured: true,
     isAcceptingPatients: true,
+    gender: 'male' as const,
   },
   {
     slug: 'sara-mizrahi',
@@ -79,6 +81,7 @@ const profiles = [
     subscriptionTier: 'premium' as const,
     isFeatured: false,
     isAcceptingPatients: false,
+    gender: 'female' as const,
   },
   {
     slug: 'david-peretz',
@@ -101,6 +104,7 @@ const profiles = [
     subscriptionTier: 'free' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'male' as const,
   },
   {
     slug: 'hana-shapira',
@@ -123,6 +127,7 @@ const profiles = [
     subscriptionTier: 'premium' as const,
     isFeatured: true,
     isAcceptingPatients: true,
+    gender: 'female' as const,
   },
   {
     slug: 'amir-hassan',
@@ -145,6 +150,7 @@ const profiles = [
     subscriptionTier: 'free' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'male' as const,
   },
   {
     slug: 'rivka-goldman',
@@ -167,6 +173,7 @@ const profiles = [
     subscriptionTier: 'premium' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'female' as const,
   },
   {
     slug: 'noa-katz',
@@ -189,6 +196,7 @@ const profiles = [
     subscriptionTier: 'free' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'female' as const,
   },
   {
     slug: 'eli-ben-david',
@@ -211,6 +219,7 @@ const profiles = [
     subscriptionTier: 'free' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'male' as const,
   },
   {
     slug: 'fatima-abu-ali',
@@ -233,6 +242,7 @@ const profiles = [
     subscriptionTier: 'free' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'female' as const,
   },
   {
     slug: 'tamar-roi',
@@ -255,6 +265,7 @@ const profiles = [
     subscriptionTier: 'free' as const,
     isFeatured: false,
     isAcceptingPatients: false,
+    gender: 'female' as const,
   },
   {
     slug: 'ron-ofer',
@@ -277,6 +288,7 @@ const profiles = [
     subscriptionTier: 'premium' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'male' as const,
   },
   {
     slug: 'orna-friedman',
@@ -299,6 +311,7 @@ const profiles = [
     subscriptionTier: 'premium' as const,
     isFeatured: true,
     isAcceptingPatients: true,
+    gender: 'female' as const,
   },
   {
     slug: 'gal-bar-oz',
@@ -321,6 +334,7 @@ const profiles = [
     subscriptionTier: 'free' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'female' as const,
   },
   {
     slug: 'moshe-dvir',
@@ -343,6 +357,7 @@ const profiles = [
     subscriptionTier: 'free' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'male' as const,
   },
   {
     slug: 'shira-landau',
@@ -365,6 +380,7 @@ const profiles = [
     subscriptionTier: 'premium' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'female' as const,
   },
   {
     slug: 'avi-nachshon',
@@ -387,6 +403,7 @@ const profiles = [
     subscriptionTier: 'free' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'male' as const,
   },
   {
     slug: 'maya-reuveni',
@@ -409,6 +426,7 @@ const profiles = [
     subscriptionTier: 'free' as const,
     isFeatured: false,
     isAcceptingPatients: false,
+    gender: 'female' as const,
   },
   {
     slug: 'dan-zarchi',
@@ -431,6 +449,7 @@ const profiles = [
     subscriptionTier: 'premium' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'male' as const,
   },
   {
     slug: 'rachel-stern',
@@ -453,6 +472,7 @@ const profiles = [
     subscriptionTier: 'premium' as const,
     isFeatured: true,
     isAcceptingPatients: true,
+    gender: 'female' as const,
   },
   {
     slug: 'tal-sela',
@@ -475,6 +495,7 @@ const profiles = [
     subscriptionTier: 'free' as const,
     isFeatured: false,
     isAcceptingPatients: true,
+    gender: 'female' as const,
   },
 ];
 

--- a/src/app/[locale]/(public)/therapist/[slug]/page.tsx
+++ b/src/app/[locale]/(public)/therapist/[slug]/page.tsx
@@ -39,6 +39,11 @@ export default async function TherapistProfilePage({ params }: TherapistProfileP
   const name = ot.displayName[locale as keyof typeof ot.displayName] ?? ot.displayName.he;
   const bio = ot.bio[locale as keyof typeof ot.bio] ?? ot.bio.he;
 
+  const titleKey =
+    ot.gender === 'male' ? 'therapistTitleMale'
+    : ot.gender === 'female' ? 'therapistTitleFemale'
+    : 'therapistTitle';
+
   const sessionUserId = (session?.user as { id?: string } | undefined)?.id ?? null;
   const userRole = (session?.user as { role?: string } | undefined)?.role ?? null;
 
@@ -68,7 +73,7 @@ export default async function TherapistProfilePage({ params }: TherapistProfileP
             <div className="flex flex-wrap items-start gap-3">
               <div>
                 <h1 className="text-2xl font-bold text-text-primary">{name}</h1>
-                <p className="text-base text-text-secondary">{t('therapistTitle')}</p>
+                <p className="text-base text-text-secondary">{t(titleKey)}</p>
               </div>
               <div className="flex flex-wrap gap-2">
                 {ot.subscriptionTier === 'premium' && (

--- a/src/app/api/dashboard/profile/route.ts
+++ b/src/app/api/dashboard/profile/route.ts
@@ -32,6 +32,7 @@ export async function PATCH(req: NextRequest) {
       'isAcceptingPatients',
       'location',
       'mohRegistrationNumber',
+      'gender',
     ];
 
     const update: Record<string, unknown> = {};

--- a/src/components/dashboard/ProfileEditForm.tsx
+++ b/src/components/dashboard/ProfileEditForm.tsx
@@ -48,6 +48,7 @@ export default function ProfileEditForm({ profile }: Props) {
   const [feeMin, setFeeMin] = useState<string>(profile.feeRange ? String(profile.feeRange.min) : '');
   const [feeMax, setFeeMax] = useState<string>(profile.feeRange ? String(profile.feeRange.max) : '');
   const [acceptingPatients, setAcceptingPatients] = useState(profile.isAcceptingPatients);
+  const [gender, setGender] = useState<'male' | 'female' | null>(profile.gender);
 
   const [saving, setSaving] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -72,6 +73,7 @@ export default function ProfileEditForm({ profile }: Props) {
       insuranceAccepted,
       languages,
       isAcceptingPatients: acceptingPatients,
+      gender,
     };
 
     if (feeMin && feeMax) {
@@ -122,6 +124,26 @@ export default function ProfileEditForm({ profile }: Props) {
           dir="ltr"
           className="mt-1.5 w-full rounded-lg border border-border bg-bg px-3.5 py-2.5 text-sm text-text-primary focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
         />
+      </Section>
+
+      {/* Gender */}
+      <Section title={t('gender')}>
+        <div className="flex flex-wrap gap-2">
+          {([['male', t('genderMale')], ['female', t('genderFemale')], [null, t('genderUnspecified')]] as [('male' | 'female' | null), string][]).map(([val, label]) => (
+            <button
+              key={String(val)}
+              type="button"
+              onClick={() => setGender(val)}
+              className={`rounded-full border px-3.5 py-1.5 text-sm font-medium transition-colors ${
+                gender === val
+                  ? 'border-primary bg-primary text-white'
+                  : 'border-border bg-bg text-text-secondary hover:border-primary/50'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </Section>
 
       {/* Location & contact */}

--- a/src/components/onboarding/TherapistOnboardingWizard.tsx
+++ b/src/components/onboarding/TherapistOnboardingWizard.tsx
@@ -12,6 +12,7 @@ interface Step1Data {
   displayNameEn: string;
   displayNameAr: string;
   languages: string[];
+  gender: 'male' | 'female' | null;
 }
 
 interface Step2Data {
@@ -178,6 +179,25 @@ function Step1({
           onChange={(v) => onChange({ displayNameAr: v })}
           dir="rtl"
         />
+      </div>
+      <div className="flex flex-col gap-2">
+        <FieldLabel>{t('gender')}</FieldLabel>
+        <div className="flex flex-wrap gap-2">
+          {([['male', t('genderMale')], ['female', t('genderFemale')], [null, t('genderUnspecified')]] as [('male' | 'female' | null), string][]).map(([val, label]) => (
+            <button
+              key={String(val)}
+              type="button"
+              onClick={() => onChange({ gender: val })}
+              className={`rounded-full border px-3.5 py-1.5 text-sm font-medium transition-colors ${
+                data.gender === val
+                  ? 'border-primary bg-primary text-white'
+                  : 'border-border bg-bg text-text-secondary hover:border-primary/50'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
       </div>
       <div className="flex flex-col gap-2">
         <FieldLabel>{t('languages')}</FieldLabel>
@@ -400,6 +420,7 @@ export default function TherapistOnboardingWizard({ therapistProfileId }: { ther
     displayNameEn: '',
     displayNameAr: '',
     languages: ['he'],
+    gender: null,
   });
   const [step2, setStep2] = useState<Step2Data>({
     city: '',
@@ -477,6 +498,7 @@ export default function TherapistOnboardingWizard({ therapistProfileId }: { ther
       contactEmail: step3.email || undefined,
       insuranceAccepted: step3.insuranceAccepted,
       isAcceptingPatients: step3.acceptingPatients,
+      gender: step1.gender,
     };
 
     if (!isNaN(feeMin) && !isNaN(feeMax) && feeMin > 0 && feeMax >= feeMin) {

--- a/src/components/search/TherapistCard.tsx
+++ b/src/components/search/TherapistCard.tsx
@@ -23,6 +23,11 @@ export default function TherapistCard({ therapist }: { therapist: TherapistProfi
 
   const isPremium = ot.subscriptionTier === 'premium';
 
+  const titleKey =
+    ot.gender === 'male' ? 'therapistTitleMale'
+    : ot.gender === 'female' ? 'therapistTitleFemale'
+    : 'therapistTitle';
+
   return (
     <article
       onClick={() => router.push(`/therapist/${ot.slug}`)}
@@ -45,7 +50,7 @@ export default function TherapistCard({ therapist }: { therapist: TherapistProfi
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div>
             <h3 className="text-base font-bold text-text-primary">{name}</h3>
-            <p className="text-sm text-text-secondary">{t('therapistTitle')}</p>
+            <p className="text-sm text-text-secondary">{t(titleKey)}</p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
             {ot.isAcceptingPatients && (

--- a/src/components/search/__tests__/TherapistCard.test.tsx
+++ b/src/components/search/__tests__/TherapistCard.test.tsx
@@ -27,8 +27,10 @@ vi.mock('@/lib/utils', () => ({
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => {
     const map: Record<string, string> = {
-      therapistTitle: 'מטפל/ת בעיסוק',
-      acceptingPatientsFilter: 'מקבל/ת מטופלים חדשים',
+      therapistTitle: 'מטפלים בעיסוק',
+      therapistTitleMale: 'מטפל בעיסוק',
+      therapistTitleFemale: 'מטפלת בעיסוק',
+      acceptingPatientsFilter: 'מקבלים מטופלים חדשים',
       messageButton: 'הודעה',
       viewProfile: 'צפה בפרופיל',
       insuranceLabel: 'ביטוח:',
@@ -65,6 +67,7 @@ const mockProfile: TherapistProfilePublic = {
   ratingAvg: 0,
   ratingCount: 0,
   createdAt: '2024-01-01T00:00:00.000Z',
+  gender: null,
 };
 
 describe('TherapistCard', () => {
@@ -91,7 +94,7 @@ describe('TherapistCard', () => {
 
   it('shows accepting patients badge when isAcceptingPatients is true', () => {
     render(<TherapistCard therapist={mockProfile} />);
-    expect(screen.getByText(/מקבל/)).toBeInTheDocument();
+    expect(screen.getByText(/מקבלים/)).toBeInTheDocument();
   });
 
   it('shows PRO badge for premium subscription', () => {

--- a/src/lib/db/models/TherapistProfile.ts
+++ b/src/lib/db/models/TherapistProfile.ts
@@ -32,6 +32,7 @@ export interface TherapistProfileDocument extends Document {
   profileViews: number;
   ratingAvg: number;
   ratingCount: number;
+  gender: 'male' | 'female' | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -90,6 +91,7 @@ const TherapistProfileSchema = new Schema<TherapistProfileDocument>(
     profileViews: { type: Number, default: 0 },
     ratingAvg: { type: Number, default: 0, min: 0, max: 5 },
     ratingCount: { type: Number, default: 0, min: 0 },
+    gender: { type: String, enum: ['male', 'female', null], default: null },
   },
   // Keep collection name as 'otprofiles' to avoid a data migration
   { timestamps: true, collection: 'otprofiles' }

--- a/src/lib/db/therapists.ts
+++ b/src/lib/db/therapists.ts
@@ -32,6 +32,7 @@ function toPublic(doc: Record<string, unknown>): TherapistProfilePublic {
     ratingAvg: (doc.ratingAvg as number) ?? 0,
     ratingCount: (doc.ratingCount as number) ?? 0,
     createdAt: (doc.createdAt as Date).toISOString(),
+    gender: (doc.gender as 'male' | 'female' | null) ?? null,
   };
 }
 

--- a/src/lib/mock-search.ts
+++ b/src/lib/mock-search.ts
@@ -66,6 +66,7 @@ function toPublic(m: (typeof MOCK_OTS)[number]): TherapistProfilePublic {
     ratingAvg: 0,
     ratingCount: 0,
     createdAt: new Date(0).toISOString(),
+    gender: null,
   };
 }
 

--- a/src/messages/ar.json
+++ b/src/messages/ar.json
@@ -22,9 +22,9 @@
     "logout": "تسجيل الخروج"
   },
   "home": {
-    "heroTitle": "اعثر على المعالج الوظيفي المناسب لك",
+    "heroTitle": "تبحث عن معالج وظيفي؟",
     "heroSubtitle": "معالجون وظيفيون خاصون في جميع أنحاء إسرائيل، يمكن البحث حسب التخصص وصندوق المرضى والموقع",
-    "searchPlaceholder": "التخصص أو اسم المعالج...",
+    "searchPlaceholder": "تخصص، اسم معالج، مدينة...",
     "searchButton": "بحث",
     "quickFilters": {
       "paediatrics": "طب الأطفال",
@@ -41,7 +41,7 @@
     "hideFilters": "إخفاء الفلاتر",
     "activeFilters": "{count} فلاتر نشطة",
     "clearFilters": "مسح الكل",
-    "acceptingPatientsFilter": "يقبل مرضى جدد",
+    "acceptingPatientsFilter": "يقبلون مرضى جدد",
     "sortBy": "ترتيب حسب",
     "sortOptions": {
       "relevance": "الصلة",
@@ -68,7 +68,9 @@
       "leumit": "لئومت",
       "private": "خاص فقط"
     },
-    "therapistTitle": "معالج/ة وظيفي",
+    "therapistTitle": "معالجون وظيفيون",
+    "therapistTitleMale": "معالج وظيفي",
+    "therapistTitleFemale": "معالجة وظيفية",
     "callButton": "اتصل",
     "contactButton": "تواصل",
     "viewProfile": "عرض الملف الشخصي",
@@ -109,7 +111,9 @@
     "fees": "رسوم الجلسة",
     "acceptingPatients": "يقبل مرضى جدد",
     "backToSearch": "العودة للبحث",
-    "therapistTitle": "معالج/ة وظيفي",
+    "therapistTitle": "معالجون وظيفيون",
+    "therapistTitleMale": "معالج وظيفي",
+    "therapistTitleFemale": "معالجة وظيفية",
     "feePerSession": "للجلسة"
   },
   "auth": {
@@ -173,6 +177,10 @@
       "feeMax": "الحد الأقصى لرسوم الجلسة (₪)",
       "mohNumber": "رقم ترخيص وزارة الصحة",
       "acceptingPatients": "أقبل مرضى جدد",
+      "gender": "الجنس",
+      "genderMale": "ذكر",
+      "genderFemale": "أنثى",
+      "genderUnspecified": "أفضل عدم الإفصاح",
       "saveError": "حدث خطأ في حفظ الملف الشخصي"
     }
   },
@@ -205,6 +213,10 @@
       "feeMin": "الحد الأدنى لرسوم الجلسة (₪)",
       "feeMax": "الحد الأقصى لرسوم الجلسة (₪)",
       "acceptingPatients": "يقبل مرضى جدد",
+      "gender": "الجنس",
+      "genderMale": "ذكر",
+      "genderFemale": "أنثى",
+      "genderUnspecified": "أفضل عدم الإفصاح",
       "saveSuccess": "تم تحديث الملف الشخصي بنجاح",
       "saveError": "خطأ في حفظ الملف الشخصي",
       "save": "حفظ التغييرات"

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -22,9 +22,9 @@
     "logout": "Log out"
   },
   "home": {
-    "heroTitle": "Find the right occupational therapist for you",
+    "heroTitle": "Looking for an occupational therapist?",
     "heroSubtitle": "Private therapists across Israel, searchable by specialisation, Kupat Holim and location",
-    "searchPlaceholder": "Specialisation or therapist name...",
+    "searchPlaceholder": "Specialisation, therapist name, city...",
     "searchButton": "Search",
     "quickFilters": {
       "paediatrics": "Paediatrics",
@@ -69,6 +69,8 @@
       "private": "Private pay"
     },
     "therapistTitle": "Occupational Therapist",
+    "therapistTitleMale": "Occupational Therapist",
+    "therapistTitleFemale": "Occupational Therapist",
     "callButton": "Call",
     "messageButton": "Message",
     "viewProfile": "View profile",
@@ -109,6 +111,8 @@
     "acceptingPatients": "Accepting new patients",
     "backToSearch": "Back to search",
     "therapistTitle": "Occupational Therapist",
+    "therapistTitleMale": "Occupational Therapist",
+    "therapistTitleFemale": "Occupational Therapist",
     "feePerSession": "per session"
   },
   "auth": {
@@ -172,6 +176,10 @@
       "feeMax": "Max session fee (₪)",
       "mohNumber": "Ministry of Health licence number",
       "acceptingPatients": "Accepting new patients",
+      "gender": "Gender",
+      "genderMale": "Male",
+      "genderFemale": "Female",
+      "genderUnspecified": "Prefer not to say",
       "saveError": "Error saving profile"
     }
   },
@@ -204,6 +212,10 @@
       "feeMin": "Min session fee (₪)",
       "feeMax": "Max session fee (₪)",
       "acceptingPatients": "Accepting new patients",
+      "gender": "Gender",
+      "genderMale": "Male",
+      "genderFemale": "Female",
+      "genderUnspecified": "Prefer not to say",
       "saveSuccess": "Profile updated successfully",
       "saveError": "Error saving profile",
       "save": "Save changes"

--- a/src/messages/he.json
+++ b/src/messages/he.json
@@ -22,9 +22,9 @@
     "logout": "יציאה"
   },
   "home": {
-    "heroTitle": "מצאו את המטפל/ת בעיסוק המתאים/ת לכם",
+    "heroTitle": "מחפשים מטפל בעיסוק?",
     "heroSubtitle": "מטפלים בעיסוק פרטיים ברחבי ישראל, חיפוש לפי התמחות, קופת חולים ומיקום",
-    "searchPlaceholder": "התמחות או שם מטפל/ת...",
+    "searchPlaceholder": "התמחות, שם מטפל, עיר...",
     "searchButton": "חיפוש",
     "quickFilters": {
       "paediatrics": "ילדים ופיתוח",
@@ -41,7 +41,7 @@
     "hideFilters": "הסתר מסננים",
     "activeFilters": "{count} מסננים פעילים",
     "clearFilters": "נקה הכל",
-    "acceptingPatientsFilter": "מקבל/ת מטופלים חדשים",
+    "acceptingPatientsFilter": "מקבלים מטופלים חדשים",
     "sortBy": "מיין לפי",
     "sortOptions": {
       "relevance": "רלוונטיות",
@@ -68,7 +68,9 @@
       "leumit": "לאומית",
       "private": "פרטי בלבד"
     },
-    "therapistTitle": "מטפל/ת בעיסוק",
+    "therapistTitle": "מטפלים בעיסוק",
+    "therapistTitleMale": "מטפל בעיסוק",
+    "therapistTitleFemale": "מטפלת בעיסוק",
     "callButton": "התקשר",
     "contactButton": "צור קשר",
     "viewProfile": "צפה בפרופיל",
@@ -107,9 +109,11 @@
     "sessionTypes": "סוגי טיפול",
     "about": "אודות",
     "fees": "עלות טיפול",
-    "acceptingPatients": "מקבל/ת מטופלים חדשים",
+    "acceptingPatients": "מקבלים מטופלים חדשים",
     "backToSearch": "חזרה לחיפוש",
-    "therapistTitle": "מטפל/ת בעיסוק",
+    "therapistTitle": "מטפלים בעיסוק",
+    "therapistTitleMale": "מטפל בעיסוק",
+    "therapistTitleFemale": "מטפלת בעיסוק",
     "feePerSession": "לטיפול"
   },
   "auth": {
@@ -172,7 +176,11 @@
       "feeMin": "מחיר מינימום לטיפול (₪)",
       "feeMax": "מחיר מקסימום לטיפול (₪)",
       "mohNumber": "מספר רישיון משרד הבריאות",
-      "acceptingPatients": "מקבל/ת מטופלים חדשים",
+      "acceptingPatients": "מקבל מטופלים חדשים",
+      "gender": "מגדר",
+      "genderMale": "זכר",
+      "genderFemale": "נקבה",
+      "genderUnspecified": "לא לציין",
       "saveError": "שגיאה בשמירת הפרופיל"
     }
   },
@@ -204,7 +212,11 @@
       "insurance": "קופות חולים",
       "feeMin": "מחיר מינימום לטיפול (₪)",
       "feeMax": "מחיר מקסימום לטיפול (₪)",
-      "acceptingPatients": "מקבל/ת מטופלים חדשים",
+      "acceptingPatients": "מקבל מטופלים חדשים",
+      "gender": "מגדר",
+      "genderMale": "זכר",
+      "genderFemale": "נקבה",
+      "genderUnspecified": "לא לציין",
       "saveSuccess": "הפרופיל עודכן בהצלחה",
       "saveError": "שגיאה בשמירת הפרופיל",
       "save": "שמור שינויים"
@@ -219,14 +231,14 @@
     "ratingLabel": "הדירוג שלך",
     "ratingRequired": "אנא בחר דירוג",
     "textLabel": "הביקורת שלך",
-    "textPlaceholder": "שתף/י את החוויה שלך עם המטפל/ת...",
+    "textPlaceholder": "שתפו את החוויה שלכם עם המטפל...",
     "textTooShort": "הביקורת חייבת להכיל לפחות 20 תווים",
     "textTooLong": "הביקורת לא יכולה לעלות על 1000 תווים",
     "submit": "שלח ביקורת",
     "submitting": "שולח...",
     "submitSuccess": "תודה! הביקורת שלך התקבלה.",
     "submitError": "שגיאה בשליחת הביקורת. נסה שוב.",
-    "alreadyReviewed": "כבר כתבת ביקורת על מטפל/ת זה/ה.",
+    "alreadyReviewed": "כבר כתבת ביקורת על מטפל זה.",
     "loginPrompt": "רוצה לשתף את החוויה שלך?",
     "loginLink": "התחבר כדי לכתוב ביקורת",
     "otCannotReview": "מטפלים בעיסוק אינם יכולים לכתוב ביקורות.",
@@ -245,7 +257,7 @@
     "phonePlaceholder": "אופציונלי",
     "subjectLabel": "נושא",
     "subjects": {
-      "newPatient": "פנייה של מטופל/ת חדש/ה",
+      "newPatient": "פנייה של מטופל חדש",
       "appointment": "בקשה לקביעת תור",
       "insurance": "שאלה על קופות חולים / עלויות",
       "general": "שאלה כללית",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,7 @@ export interface TherapistProfilePublic {
   ratingAvg: number;
   ratingCount: number;
   createdAt: string;
+  gender: 'male' | 'female' | null;
 }
 
 export interface ReviewPublic {


### PR DESCRIPTION
## Summary
- Full rename of `OT` → `Therapist` across all code symbols, URLs, API routes, models, types and components
- Add `gender` field (`'male'|'female'|null`) end-to-end: type → schema → API → gender-resolved title on TherapistCard and profile page
- Onboarding wizard and ProfileEditForm: pill-button gender selector
- Remove all slash-gender notation from Hebrew strings (`מקבל/ת`, `מטפל/ת`, `שתף/י`, etc.)
- Rewrite `heroTitle` to approachable "looking for?" style across all 3 locales
- Update `searchPlaceholder` to include city hint in all 3 locales
- Assign correct gender to all 21 seed therapists

## Test plan
- [ ] `npm run typecheck` — clean
- [ ] `npm run test` — 24/24 passing
- [ ] `/he/search` — cards show מטפלים/מטפל/מטפלת based on gender
- [ ] `/he/` — hero shows "מחפשים מטפל בעיסוק?"
- [ ] Onboarding Step 1 — gender pill buttons visible
- [ ] Profile edit form — gender selector visible
- [ ] Old URL `/ot/[slug]` redirects to `/therapist/[slug]`

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)